### PR TITLE
init: don't hardcode ro.hardware

### DIFF
--- a/init.rc
+++ b/init.rc
@@ -1,6 +1,6 @@
 on fs
-    mount_all /fstab.unknown
-    swapon_all /fstab.unknown
+    mount_all /fstab.${ro.hardware}
+    swapon_all /fstab.${ro.hardware}
 
 on init
     # See storage config details at http://source.android.com/tech/storage/


### PR DESCRIPTION
This would allow re-using the same init.rc file as template for other hw-specific device.mk files.