### PR TITLE
BoardConfig.mk: don't use LOCAL_PATH in included files

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -37,11 +37,5 @@ BOARD_SEPOLICY_DIRS += \
 	build/target/board/generic/sepolicy \
 	$(DEV_DIR)/sepolicy
 
-define include-board-configs
- $(foreach dir, $(1), \
-  $(eval LOCAL_PATH := $(DEV_DIR)/$(dir)) \
-  $(eval sinclude $(LOCAL_PATH)/BoardConfig.mk) \
- )
-endef
-
-$(call include-board-configs, wifi/qcom-flo graphics/drm)
+-include $(DEV_DIR)/wifi/qcom-flo/BoardConfig.mk
+-include $(DEV_DIR)/graphics/drm/BoardConfig.mk

--- a/graphics/drm/BoardConfig.mk
+++ b/graphics/drm/BoardConfig.mk
@@ -1,2 +1,2 @@
 BOARD_SEPOLICY_DIRS += \
-	$(LOCAL_PATH)/sepolicy
+	$(DEV_DIR)/graphics/drm/sepolicy

--- a/wifi/qcom-flo/BoardConfig.mk
+++ b/wifi/qcom-flo/BoardConfig.mk
@@ -1,2 +1,2 @@
 BOARD_SEPOLICY_DIRS += $(if $(CONFIG_QCOM_FLO_WIFI), \
-	$(LOCAL_PATH)/sepolicy)
+	$(DEV_DIR)/wifi/qcom-flo/sepolicy)


### PR DESCRIPTION
The LOCAL_PATH variable defined within the top-level BoardConfig.mk
for each included BoardConfig.mk doesn't seem to work properly. The
outcome of this issue is that SELinux labels aren't applied properly:

    $ ls -ltrZ /system/bin/conn_init
    -rwxr-xr-x 1 root shell u:object_r:system_file:s0 22740 2017-07-12 16:54 /system/bin/conn_init

With the patch applied, we do get the files correctly labeled:

    $ ls -ltrZ /system/bin/conn_init
    -rwxr-xr-x 1 root shell u:object_r:conn_init_exec:s0 22740 2017-07-12 16:54 /system/bin/conn_init

Also, simplify the inclusion of the BoardConfig.mk files in the parent
one.

Signed-off-by: Aleksander Morgado <aleksander@aleksander.es>