### PR TITLE
Stop labling mmc devices as sdcards

### DIFF
--- a/fstab
+++ b/fstab
@@ -7,7 +7,6 @@ LABEL=vendor            /vendor             ext4      ro                        
 LABEL=cache             /cache              ext4      noatime,nosuid,nodev,errors=panic    wait
 LABEL=data              /data               ext4      noatime,nosuid,nodev,errors=panic    wait
 */block/sd*             auto                auto      defaults  voldmanaged=usbdisk:auto,encryptable=userdata
-*/block/mmcblk*         auto                auto      defaults  voldmanaged=sdcard1:auto,encryptable=userdata
 
 # Enable ZRAM swap
 /dev/block/zram0        none                swap      defaults                                             zramsize=533413200,notrim


### PR DESCRIPTION
this can go VERY badly on devices using mmc as main storage